### PR TITLE
Refresh msys2 toolchain

### DIFF
--- a/ci/setup-msys2.yml
+++ b/ci/setup-msys2.yml
@@ -71,6 +71,7 @@ steps:
     set PATH=%SUPERBUILD_INSTALL_DIR_NATIVE%\usr\bin;%WINDIR%\system32;%WINDIR%;%WINDIR%\system32\wbem
     pacman --noconfirm -S --needed ^
       bison ^
+      diffutils ^
       gzip ^
       make ^
       patch ^

--- a/libpolyclipping-6.4.2-3.cmake
+++ b/libpolyclipping-6.4.2-3.cmake
@@ -71,9 +71,12 @@ superbuild_package(
       "${CMAKE_COMMAND}"
         -Dpackage=libpolyclipping-patches-${patch_version}
         -P "${APPLY_PATCHES_SERIES}"
-    # On Windows, shared libraries count as RUNTIME, not LIBRARY.
+    # On Windows, import libraries count as ARCHIVE
     COMMAND
-      sed -i -e [[ s/LIBRARY DESTINATION/RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}\/bin" LIBRARY DESTINATION/ ]] cpp/CMakeLists.txt
+      sed -i -e [[ s/polyclipping LIBRARY DESTINATION/polyclipping ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" LIBRARY DESTINATION/ ]] cpp/CMakeLists.txt
+    # On Windows, shared libraries count as RUNTIME.
+    COMMAND
+      sed -i -e [[ s/polyclipping ARCHIVE DESTINATION/polyclipping RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}\/bin" ARCHIVE DESTINATION/ ]] cpp/CMakeLists.txt
 )
 
 # Build from a copy of the cpp directory, using ExternalPackage's CMake support


### PR DESCRIPTION
Significant changes from msys2:
- gcc 9.3.0
- cmake 3.17
- mingw-w64 pre-8.0.0