### PR TITLE
sqlite3: Update to 3.33.0-1

### DIFF
--- a/sqlite3-3.33.0.cmake
+++ b/sqlite3-3.33.0.cmake
@@ -27,12 +27,12 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set(version           3.32.2)
-set(download_version  2020/sqlite-autoconf-3320200)
-set(download_hash     SHA1=429e3f2d0b16a95ad1025a97b2a328d0b4037575)
-set(patch_version     ${version}-2)
-set(patch_hash        SHA256=c6dff4a12116e369fbdbeba4ad4f532b673bd87405fcf9ad9c1dd906062bc46d)
-set(base_url          https://snapshot.debian.org/archive/debian/20200606T204857Z/pool/main/s/sqlite3/)
+set(version           3.33.0)
+set(download_version  2020/sqlite-autoconf-3330000)
+set(download_hash     SHA3_256=6e94e9453cedf8f2023e3923f856741d1e28a2271e9f93d24d95fa48870edaad)
+set(patch_version     ${version}-1)
+set(patch_hash        SHA256=acbfdb13e248e43e8eaf19654d48070f37738ee522c79d6229797115d2ded45c)
+set(base_url          https://snapshot.debian.org/archive/debian/20200815T204602Z/pool/main/s/sqlite3/)
 
 option(USE_SYSTEM_SQLITE3 "Use the system sqlite if possible" ON)
 
@@ -72,6 +72,11 @@ superbuild_package(
   SOURCE
     URL            https://www.sqlite.org/${download_version}.tar.gz
     URL_HASH       ${download_hash}
+    PATCH_COMMAND
+      # __USE_GNU is defined on Android, but compiling and linking find only the
+      # POSIX version of strerror_r, issueing a warning.
+      # Just rely on configure's feature detection.
+      sed -e "/STRERROR_R_CHAR_P/ s/ .. defined.__USE_GNU.//" -i -- sqlite3.c
   
   USING            USE_SYSTEM_SQLITE3 version patch_version
   BUILD_CONDITION  ${test_system_sqlite3}


### PR DESCRIPTION
Upstream now uses SHA3-256 checksum. This needs cmake 3.8.
In additon, fix strerrror_r usage on Android.