### PR TITLE
Resolve libjpeg-turbo dynamic linking issue

### DIFF
--- a/libpng1.6-1.6.37.cmake
+++ b/libpng1.6-1.6.37.cmake
@@ -49,7 +49,7 @@ set(test_system_png [[
 				get_target_property(png_location PNG::PNG "IMPORTED_LOCATION")
 			endif()
 			string(FIND "${png_location}" "${CMAKE_STAGING_PREFIX}/" staging_prefix_start)
-			if(NOT staging_prefix_start EQUAL 0)
+			if(EXISTS "${png_location}" AND NOT staging_prefix_start EQUAL 0)
 				message(STATUS "Found ${SYSTEM_NAME} libpng: ${png_location}")
 				set(BUILD_CONDITION 0)
 			endif()

--- a/libwebp-1.1.0.cmake
+++ b/libwebp-1.1.0.cmake
@@ -57,7 +57,7 @@ superbuild_package(
   VERSION        ${patch_version}
   DEPENDS
     giflib
-    libjpeg-turbo
+    libjpeg
     libpng
     zlib
   

--- a/libwebp-1.1.0.cmake
+++ b/libwebp-1.1.0.cmake
@@ -84,6 +84,7 @@ superbuild_package(
       -DWEBP_BUILD_WEBPMUX=OFF
       -DWEBP_BUILD_EXTRAS=OFF
       -DWEBP_BUILD_WEBP_JS=OFF
+      -DCMAKE_DISABLE_FIND_PACKAGE_TIFF=ON # Our libtiff depends on libwebp.
     INSTALL_COMMAND
       "${CMAKE_COMMAND}" --build . --target install/strip/fast
     COMMAND

--- a/libwebp-1.1.0.cmake
+++ b/libwebp-1.1.0.cmake
@@ -57,7 +57,6 @@ superbuild_package(
   VERSION        ${patch_version}
   DEPENDS
     giflib
-    libjpeg
     libpng
     zlib
   
@@ -84,6 +83,7 @@ superbuild_package(
       -DWEBP_BUILD_WEBPMUX=OFF
       -DWEBP_BUILD_EXTRAS=OFF
       -DWEBP_BUILD_WEBP_JS=OFF
+      -DCMAKE_DISABLE_FIND_PACKAGE_JPEG=ON
       -DCMAKE_DISABLE_FIND_PACKAGE_TIFF=ON # Our libtiff depends on libwebp.
     INSTALL_COMMAND
       "${CMAKE_COMMAND}" --build . --target install/strip/fast

--- a/poppler-20.09.cmake
+++ b/poppler-20.09.cmake
@@ -118,6 +118,7 @@ superbuild_package(
       -DCMAKE_DISABLE_FIND_PACKAGE_NSS3=ON
       ${poppler_font_configuration}
       $<$<BOOL:@ANDROID@>:
+        -DJPEG_NAMES=jpeg-turbo
         -D_FILE_OFFSET_BITS=
       >
    INSTALL_COMMAND

--- a/qt-5.12.9.cmake
+++ b/qt-5.12.9.cmake
@@ -115,7 +115,7 @@ superbuild_package(
   DEPENDS
     source:qt-${short_version}-openorienteering-${openorienteering_version}
     freetype
-    libjpeg-turbo
+    libjpeg
     libpng
     pcre2
     sqlite3

--- a/qt-5.12.9.cmake
+++ b/qt-5.12.9.cmake
@@ -118,6 +118,7 @@ superbuild_package(
     libjpeg
     libpng
     pcre2
+    pkg-config
     sqlite3
     zlib
   
@@ -172,6 +173,11 @@ superbuild_package(
          --unset=CFLAGS
          --unset=CXXFLAGS
          --unset=LDFLAGS
+         $<@android@:
+           # Required to satisfy qconfigure.pri
+           PKG_CONFIG_SYSROOT_DIR=set-but-not-used
+           PKG_CONFIG_LIBDIR=set-but-not-used
+         >
          # fall through
     >
     "${SOURCE_DIR}/configure"
@@ -221,7 +227,6 @@ superbuild_package(
         -opengl desktop
       >
       $<@crosscompiling@:
-        -no-pkg-config
         -hostprefix "${HOST_PREFIX}"
         #-hostdatadir "${HOST_PREFIX}/share/qt5"
         $<@windows@:
@@ -231,6 +236,7 @@ superbuild_package(
           -no-feature-systemtrayicon # Workaround missing ChangeWindowMessageFilterEx symbol
         >
         $<@android@:
+          -pkg-config
           $<$<STREQUAL:@CMAKE_CXX_COMPILER_ID@,GNU>:
             -xplatform     android-g++
           >$<$<STREQUAL:@CMAKE_CXX_COMPILER_ID@,Clang>:

--- a/qt-5.12.9.cmake
+++ b/qt-5.12.9.cmake
@@ -30,7 +30,7 @@
 set(short_version  5.12)
 set(version        5.12.7)
 set(patch_version  ${version}-0)
-set(openorienteering_version ${version}-qtbase-5.12.9-0)
+set(openorienteering_version ${version}-qtbase-5.12.9-1)
 
 option(USE_SYSTEM_QT "Use the system Qt if possible" ON)
 
@@ -92,7 +92,7 @@ superbuild_package(
   
   SOURCE
     URL            https://github.com/OpenOrienteering/superbuild/archive/qt-${short_version}-openorienteering_${openorienteering_version}.tar.gz
-    URL_HASH       SHA256=03af9d83105bc563ebafbd285e6df6f872b71081ee19c64daa5b3908c6d6fc7e
+    URL_HASH       SHA256=eb7467508ab79ed3a38101ae671b1751cdcb1dfe6c166d7726783f31e3f642aa
 )
 
 

--- a/tiff-4.1.0.cmake
+++ b/tiff-4.1.0.cmake
@@ -107,6 +107,9 @@ superbuild_package(
       # We don't provide all possible sources (yet)
       "-Djbig:BOOL=OFF"
       "-Dzstd:BOOL=OFF"
+      $<$<BOOL:@ANDROID@>:
+        -DJPEG_NAMES=jpeg-turbo
+      >
       # GNUInstallDirs doesn't work with CMAKE_STAGING_PREFIX
       -UCMAKE_STAGING_PREFIX
     INSTALL_COMMAND

--- a/tiff-4.1.0.cmake
+++ b/tiff-4.1.0.cmake
@@ -51,7 +51,7 @@ set(test_system_tiff [[
 				get_target_property(tiff_location TIFF::TIFF "IMPORTED_LOCATION")
 			endif()
 			string(FIND "${tiff_location}" "${CMAKE_STAGING_PREFIX}/" staging_prefix_start)
-			if(NOT staging_prefix_start EQUAL 0)
+			if(EXISTS "${tiff_location}" AND NOT staging_prefix_start EQUAL 0)
 				message(STATUS "Found ${SYSTEM_NAME} libtiff: ${tiff_location}")
 				set(BUILD_CONDITION 0)
 			endif()


### PR DESCRIPTION
When using libjpeg-turbo as a shared object (libjpeg.so) on Android,    there are crashes when accessing JPEG functions on some arm devices.    Static linking increases binary size when the library is used by    multiple other shared objects (Qt plugin, GDAL, Poppler, TIFF).
    
Assuming that the issue is related to some other "libjpeg.so", try    to resolve the dynamic linking issue by changing the filename to    "libjpeg-turbo.so" in Android builds.
    
Some depending libraries can find the alternative name via    pkg-config. Depending CMake projects must be configured with    `-DJPEG_NAMES=jpeg-turbo`.