### PR TITLE
Add libkml and its dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1399,7 +1399,8 @@ function(superbuild_package)
 	get_property(default_version GLOBAL PROPERTY SB_DEFAULT_${SB_PACKAGE_NAME})
 	string(REPLACE "-" "." default_version "${default_version}")
 	if(NOT SB_PACKAGE_NO_DEFAULT
-	   AND version VERSION_GREATER default_version)
+	   AND (NOT default_version
+	        OR version VERSION_GREATER default_version))
 		set_property(GLOBAL PROPERTY SB_DEFAULT_${SB_PACKAGE_NAME} ${SB_PACKAGE_VERSION})
 	endif()
 endfunction()

--- a/boost-1.71.0.cmake
+++ b/boost-1.71.0.cmake
@@ -1,0 +1,125 @@
+# This file is part of OpenOrienteering.
+
+# Copyright 2020 Kai Pastor
+#
+# Redistribution and use is allowed according to the terms of the BSD license:
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 
+# 1. Redistributions of source code must retain the copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. The name of the author may not be used to endorse or promote products 
+#    derived from this software without specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+set(version        1.71.0)
+set(download_hash  SHA256=e30fb3f666df75fc2ba23403ccbd8bcb0ee5595dc099412b4abde7a9fdde3918)
+set(patch_version  ${version}-7)
+set(patch_hash     SHA256=5dd716c499d68bdb977061e9540df641a0c88d4546c74f7a578ff51369839cba)
+set(base_url       https://snapshot.debian.org/archive/debian/20201012T150222Z/pool/main/b/boost1.71/)
+
+option(USE_SYSTEM_BOOST "Use the system Boost Libraries if possible" ON)
+
+set(test_system_boost [[
+	if(${USE_SYSTEM_BOOST})
+		enable_language(C)
+		find_package(Boost QUIET)
+		if(Boost_FOUND)
+			string(FIND "${BOOST_INCLUDE_DIR}" "${CMAKE_STAGING_PREFIX}/" staging_prefix_start)
+			if(BOOST_INCLUDE_DIR AND NOT staging_prefix_start EQUAL 0)
+				message(STATUS "Found ${SYSTEM_NAME} Boost Libraries: ${BOOST_INCLUDE_DIR}")
+				set(BUILD_CONDITION 0)
+			endif()
+		endif()
+	endif()
+]])
+
+superbuild_package(
+  NAME           boost1.71-patches
+  VERSION        ${patch_version}
+  
+  SOURCE
+    URL            ${base_url}boost1.71_${patch_version}.debian.tar.xz
+    URL_HASH       ${patch_hash}
+)
+  
+superbuild_package(
+  NAME           boost1.71-bootstrap
+  VERSION        ${patch_version}
+  DEPENDS
+    source:boost1.71-patches-${patch_version}
+    host:bison
+  
+  SOURCE
+    URL            ${base_url}boost1.71_${version}.orig.tar.xz
+    URL_HASH       ${download_hash}
+    PATCH_COMMAND
+      "${CMAKE_COMMAND}"
+        -Dpackage=boost1.71-patches-${patch_version}
+        -P "${APPLY_PATCHES_SERIES}"
+  
+  USING            USE_SYSTEM_BOOST patch_version
+  BUILD_CONDITION  ${test_system_boost}
+  BUILD [[
+    # Cannot do out-of-source build of boost
+    CONFIGURE_COMMAND
+      "${CMAKE_COMMAND}" -E make_directory "${BINARY_DIR}"
+    COMMAND
+      "${CMAKE_COMMAND}" -E copy_directory "${SOURCE_DIR}" "${BINARY_DIR}"
+    BUILD_COMMAND
+      "${CMAKE_COMMAND}" -E chdir tools/build bison -y -d -o src/engine/jamgram.cpp src/engine/jamgram.y
+    COMMAND
+      sh ./bootstrap.sh --without-icu --prefix=${DESTDIR}${CMAKE_STAGING_PREFIX}
+    COMMAND
+      ./b2 tools/bcp
+    COMMAND
+      ./b2 --with-headers
+    INSTALL_COMMAND
+      ""
+  ]]
+)
+
+superbuild_package(
+  NAME           boost-smart_ptr
+  VERSION        ${patch_version}
+  DEPENDS
+    host:boost1.71-bootstrap
+  
+  SOURCE           boost1.71-bootstrap-${patch_version}
+  
+  USING            USE_SYSTEM_BOOST patch_version
+  BUILD_CONDITION  ${test_system_boost}
+  BUILD [[
+    CONFIGURE_COMMAND
+      ""
+    BUILD_COMMAND
+      ""
+    INSTALL_COMMAND
+      "${CMAKE_COMMAND}" -E make_directory "${DESTDIR}${CMAKE_STAGING_PREFIX}/include"
+    COMMAND
+      "${CMAKE_COMMAND}" -E chdir "<BINARY_DIR>/../../default/boost1.71-bootstrap-${patch_version}"
+        ./dist/bin/bcp boost/scoped_ptr.hpp "${DESTDIR}${CMAKE_STAGING_PREFIX}/include"
+    COMMAND
+      "${CMAKE_COMMAND}" -E chdir "<BINARY_DIR>/../../default/boost1.71-bootstrap-${patch_version}"
+        ./dist/bin/bcp boost/intrusive_ptr.hpp "${DESTDIR}${CMAKE_STAGING_PREFIX}/include"
+    COMMAND
+      "${CMAKE_COMMAND}" -E copy
+        "<BINARY_DIR>/../../source/boost1.71-patches-${patch_version}/copyright"
+        "${DESTDIR}${CMAKE_STAGING_PREFIX}/share/doc/copyright/boost-${patch_version}.txt"
+  ]]
+)

--- a/ci/setup-msys2.yml
+++ b/ci/setup-msys2.yml
@@ -77,6 +77,7 @@ steps:
       make ^
       patch ^
       python ^
+      sharutils ^
       mingw-w64-%MSYSTEM_CARCH%-binutils ^
       mingw-w64-%MSYSTEM_CARCH%-cmake ^
       mingw-w64-%MSYSTEM_CARCH%-gcc ^

--- a/ci/setup-ubuntu.yml
+++ b/ci/setup-ubuntu.yml
@@ -36,7 +36,8 @@ steps:
     sudo apt-get install \
       doxygen graphviz python-lxml \
       g++-mingw-w64-x86-64 \
-      '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev
+      '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev \
+      sharutils
     
     sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
     

--- a/freetype-2.10.4+dfsg.cmake
+++ b/freetype-2.10.4+dfsg.cmake
@@ -27,11 +27,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set(version        2.10.2+dfsg)
-set(download_hash  SHA256=c1f32cbb42a1519ae7d69046d84d359f44bfdea15c800c4f0b60a36c78b46d70)
-set(patch_version  ${version}-4)
-set(patch_hash     SHA256=5bebdcf8e764b5a4a6a5f4f4201abb7b3356599cadaed3aae37f344ef346341f)
-set(base_url       https://snapshot.debian.org/archive/debian/20201021T155324Z/pool/main/f/freetype/)
+set(version        2.10.4+dfsg)
+set(download_hash  SHA256=db0c0938b3b75cf314775baa75198098e41583b3aaa4804b454f183ce45120a9)
+set(patch_version  ${version}-1)
+set(patch_hash     SHA256=96276d66eb56247545cd9e60ffae0bd5b5aee0490e4e7171337a6666bc51b125)
+set(base_url       https://snapshot.debian.org/archive/debian/20201208T212129Z/pool/main/f/freetype/)
 
 option(USE_SYSTEM_FREETYPE "Use the system Freetype if possible" ON)
 

--- a/gdal-3.1.4+dfsg.cmake
+++ b/gdal-3.1.4+dfsg.cmake
@@ -60,6 +60,12 @@ set(test_system_gdal [[
 		endif()
 		get_filename_component(EXPAT_DIR "${EXPAT_INCLUDE_DIR}" DIRECTORY CACHE)
 		
+		find_path(LIBKML_INCLUDE_DIR NAMES kml/engine.h QUIET)
+		if(NOT LIBKML_INCLUDE_DIR)
+			message(FATAL_ERROR "Could not find kml/engine.h")
+		endif()
+		get_filename_component(LIBKML_DIR "${LIBKML_INCLUDE_DIR}" DIRECTORY CACHE)
+		
 		find_path(SQLITE3_INCLUDE_DIR NAMES sqlite3.h QUIET)
 		if(NOT SQLITE3_INCLUDE_DIR)
 			message(FATAL_ERROR "Could not find sqlite3.h")
@@ -69,6 +75,7 @@ set(test_system_gdal [[
 	
 	set(extra_cflags   "-Wno-strict-overflow -Wno-null-dereference" PARENT_SCOPE)
 	set(extra_cxxflags "-Wno-strict-overflow -Wno-null-dereference -Wno-old-style-cast" PARENT_SCOPE)
+	set(extra_ldflags  "-lminizip")
 ]])
 
 set(libjpeg_patch [[
@@ -166,6 +173,7 @@ superbuild_package(
     giflib
     libiconv
     libjpeg
+    libkml
     liblzma
     libpng
     libwebp
@@ -190,7 +198,7 @@ superbuild_package(
     COMMAND
       patch -p1 < libjpeg.patch
   
-  USING            USE_SYSTEM_GDAL patch_version extra_cflags extra_cxxflags
+  USING            USE_SYSTEM_GDAL patch_version extra_cflags extra_cxxflags extra_ldflags
   BUILD_CONDITION  ${test_system_gdal}
   BUILD [[
     # Cannot do out-of-source build of gdal
@@ -216,20 +224,20 @@ superbuild_package(
         "--with-expat=${EXPAT_DIR}"
         --with-gif
         --with-jpeg
+        "--with-libkml=${LIBKML_DIR}"
         --with-liblzma
         --with-libtiff
-        --with-poppler
-        --with-webp
         --with-libz
         --with-openjpeg
         --with-pcre
         --with-png
+        --with-poppler
         --with-proj
         "--with-sqlite3=${SQLITE3_DIR}"
+        --with-webp
         --without-geos
         --without-java
         --without-jpeg12
-        --without-libkml
         --without-netcdf
         --without-odbc
         --without-ogdi
@@ -248,7 +256,7 @@ superbuild_package(
         "CPPFLAGS=${SUPERBUILD_CPPFLAGS}"
         "CFLAGS=${SUPERBUILD_CFLAGS} ${extra_cflags}"
         "CXXFLAGS=${SUPERBUILD_CXXFLAGS} ${extra_cxxflags}"
-        "LDFLAGS=${SUPERBUILD_LDFLAGS}"
+        "LDFLAGS=${SUPERBUILD_LDFLAGS} ${extra_ldflags}"
     BUILD_COMMAND
       "$(MAKE)"
     INSTALL_COMMAND

--- a/libkml-1.3.0.cmake
+++ b/libkml-1.3.0.cmake
@@ -1,0 +1,191 @@
+# This file is part of OpenOrienteering.
+
+# Copyright 2020 Kai Pastor
+#
+# Redistribution and use is allowed according to the terms of the BSD license:
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 
+# 1. Redistributions of source code must retain the copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. The name of the author may not be used to endorse or promote products 
+#    derived from this software without specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+set(version        1.3.0)
+set(download_hash  SHA256=8892439e5570091965aaffe30b08631fdf7ca7f81f6495b4648f0950d7ea7963)
+set(patch_version  ${version}-9)
+set(patch_hash     SHA256=595b5c7f2de4c73a784c0cdf5014a2321739a4f3f53437eb31e3fe7509e0f1d5)
+set(base_url       https://snapshot.debian.org/archive/debian/20201111T205648Z/pool/main/libk/libkml/)
+
+option(USE_SYSTEM_LIBKML "Use the system LibKML if possible" ON)
+
+set(test_system_libkml [[
+	if(${USE_SYSTEM_LIBKML})
+		enable_language(C)
+		find_package(LibKML CONFIG QUIET)
+		find_package(LibKML MODULE QUIET)
+		string(FIND "${LIBKML_LIBRARIES}" "${CMAKE_STAGING_PREFIX}/" staging_prefix_start)
+		if(LibKML_FOUND AND LIBKML_LIBRARIES AND NOT staging_prefix_start EQUAL 0)
+			message(STATUS "Found ${SYSTEM_NAME} LibKML: ${LIBKML_LIBRARY}")
+			set(BUILD_CONDITION 0)
+		endif()
+	endif()
+	
+	if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+		set(extra_flags "-Wno-dangling-else -Wno-parentheses-equality" PARENT_SCOPE)
+	else()
+		set(extra_flags "" PARENT_SCOPE)
+	endif()
+]])
+
+set(strptime_c_sed [[
+/^if.WIN32./a \
+  list(APPEND SRCS "${CMAKE_CURRENT_SOURCE_DIR}/contrib/netbsd-strptime.c")
+]])
+
+set(strptime_c_copyright [[
+Files: src/kml/base/contrib/netbsd-strptime.c
+Copyright: 1997, 1998, 2005, 2008 The NetBSD Foundation, Inc.
+Comment: Copyright (c) 1997, 1998, 2005, 2008 The NetBSD Foundation, Inc.
+ All rights reserved.
+ .
+ This code was contributed to The NetBSD Foundation by Klaus Klein.
+ Heavily optimised by David Laight
+License:
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ ]])
+
+superbuild_package(
+  NAME           libkml-patches
+  VERSION        ${patch_version}
+  
+  SOURCE_WRITE
+    strptime_c-copyright  strptime_c_copyright
+  SOURCE
+    URL            ${base_url}libkml_${patch_version}.debian.tar.xz
+    URL_HASH       ${patch_hash}
+    PATCH_COMMAND
+      sed -e "/^python3.patch/d" -i -- patches/series
+    COMMAND
+      sed -e "/strptime/,$ d" -i -- copyright
+    COMMAND
+      sed -e "$ r strptime_c-copyright" -i -- copyright
+)
+
+superbuild_package(
+  NAME           libkml-mingw-patch
+  VERSION        ${version}
+  
+  SOURCE
+    URL            https://raw.githubusercontent.com/msys2/MINGW-packages/d5535441b7435a0e7a7d7dee83b175eae7b48475/mingw-w64-libkml/001-libkml-1.3.0.patch
+    URL_HASH       SHA256=3692ee34904bbc2ba9a186df80e8d870162abf973151cb16715f26b752020875
+    DOWNLOAD_NAME  libkml-${version}-mingw.patch
+    DOWNLOAD_NO_EXTRACT 1
+)
+
+superbuild_package(
+  NAME           libkml-strptime-c
+  VERSION        ${version}
+  
+  SOURCE
+    URL            https://raw.githubusercontent.com/msys2/MINGW-packages/d5535441b7435a0e7a7d7dee83b175eae7b48475/mingw-w64-libkml/strptime.c
+    URL_HASH       SHA256=49433be91643aaccef032ded7d413782a6ed62f545883165814e13c0e1f4182c
+    DOWNLOAD_NAME  libkml-${version}-strptime.c
+    DOWNLOAD_NO_EXTRACT 1
+)
+
+superbuild_package(
+  NAME           libkml
+  VERSION        ${patch_version}
+  DEPENDS
+    source:libkml-patches-${patch_version}
+    source:libkml-mingw-patch-${version}
+    source:libkml-strptime-c-${version}
+    boost-smart_ptr
+    expat
+#    googletest
+    minizip
+    uriparser
+    zlib
+  
+  SOURCE_WRITE
+    strptime_c.sed   strptime_c_sed
+  SOURCE
+    URL            ${base_url}libkml_${version}.orig.tar.gz
+    URL_HASH       ${download_hash}
+    PATCH_COMMAND
+      "${CMAKE_COMMAND}"
+        -Dpackage=libkml-patches-${patch_version}
+        -P "${APPLY_PATCHES_SERIES}"
+    COMMAND
+      sed -e "s/ZLIB 1.2.8/ZLIB 1.2.7/" -i -- CMakeLists.txt
+    COMMAND
+      patch -p1 < "<DOWNLOAD_DIR>/libkml-${version}-mingw.patch"
+    COMMAND
+      cmake -E copy "<DOWNLOAD_DIR>/libkml-${version}-strptime.c" "src/kml/base/contrib/netbsd-strptime.c"
+    COMMAND
+      sed -f strptime_c.sed -i -- src/kml/base/CMakeLists.txt
+    COMMAND
+      "${CMAKE_COMMAND}" -E remove -f
+        cmake/External_boost.cmake
+        cmake/External_expat.cmake
+        cmake/External_minizip.cmake
+        cmake/External_uriparser.cmake
+        cmake/External_zlib.cmake
+  
+  USING            USE_SYSTEM_LIBKML patch_version extra_flags
+  BUILD_CONDITION  ${test_system_libkml}
+  BUILD [[
+    CMAKE_ARGS
+      "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}"
+      "-DCMAKE_BUILD_TYPE:STRING=$<CONFIG>"
+      "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS} ${extra_flags}"
+      -DBUILD_SHARED_LIBS=ON
+      -DBoost_FOUND=ON
+#      $<$<NOT:$<BOOL:@CMAKE_CROSSCOMPILING@>>:
+#        -DBUILD_TESTING=ON
+#        "-DGTEST_INCLUDE_DIR=${DESTDIR}${CMAKE_STAGING_PREFIX}/include"
+#      >
+   INSTALL_COMMAND
+     "${CMAKE_COMMAND}" --build . --target install/strip/fast -- DESTDIR=${DESTDIR}${INSTALL_DIR}
+   COMMAND
+     "${CMAKE_COMMAND}" -E copy
+       "<SOURCE_DIR>/../libkml-patches-${patch_version}/copyright"
+       "${DESTDIR}${CMAKE_STAGING_PREFIX}/share/doc/copyright/libkml-${patch_version}.txt"
+  ]]
+)

--- a/openorienteering-mapper-git.cmake
+++ b/openorienteering-mapper-git.cmake
@@ -107,6 +107,7 @@ foreach(git_tag ${Mapper_GIT_TAGS})
 	  >
 	  $<$<NOT:$<BOOL:@CMAKE_CROSSCOMPILING@>>:
 	    TEST_COMMAND
+	      "${CMAKE_COMMAND}" -E env "LD_LIBRARY_PATH=${CMAKE_STAGING_PREFIX}/lib"
 	      "${CMAKE_CTEST_COMMAND}" -T Test --no-compress-output
 	    TEST_BEFORE_INSTALL 1
 	  >

--- a/poppler-20.09.cmake
+++ b/poppler-20.09.cmake
@@ -115,6 +115,7 @@ superbuild_package(
       -DBUILD_QT5_TESTS=OFF
       -DENABLE_LIBCURL=OFF
       -DRUN_GPERF_IF_PRESENT=OFF
+      -DCMAKE_DISABLE_FIND_PACKAGE_Boost=ON
       -DCMAKE_DISABLE_FIND_PACKAGE_NSS3=ON
       ${poppler_font_configuration}
       $<$<BOOL:@ANDROID@>:

--- a/proj-7.1.1.cmake
+++ b/proj-7.1.1.cmake
@@ -81,6 +81,9 @@ superbuild_package(
     COMMAND
       "${CMAKE_COMMAND}" -E chdir "<SOURCE_DIR>/data"
         sh "<SOURCE_DIR>/datumgrids.shar" -c
+    COMMAND
+      # Verify existence of a file from datumgrids.shar
+      "${CMAKE_COMMAND}" -E md5sum "<SOURCE_DIR>/data/BETA2007.gsb"
     #COMMAND
     #  "${CMAKE_COMMAND}" -E chdir "<SOURCE_DIR>/data"
     #    sh "<SOURCE_DIR>/datumgrids-ch.shar" -c

--- a/qt-5.12.10.cmake
+++ b/qt-5.12.10.cmake
@@ -30,7 +30,7 @@
 set(short_version  5.12)
 set(version        5.12.7)
 set(patch_version  ${version}-0)
-set(openorienteering_version ${version}-qtbase-5.12.9-1)
+set(openorienteering_version ${version}-qtbase-5.12.10-0)
 
 option(USE_SYSTEM_QT "Use the system Qt if possible" ON)
 
@@ -102,14 +102,14 @@ superbuild_package(
   
   SOURCE
     URL            https://github.com/OpenOrienteering/superbuild/archive/qt-${short_version}-openorienteering_${openorienteering_version}.tar.gz
-    URL_HASH       SHA256=eb7467508ab79ed3a38101ae671b1751cdcb1dfe6c166d7726783f31e3f642aa
+    URL_HASH       SHA256=fa6bd764f42b32bdf3cea6999d26edb319f41cf1dba4995b062e31740076e5fe
 )
 
 
 
 # qtbase
 
-set(qtbase_version       5.12.9)
+set(qtbase_version       5.12.10)
 set(qtbase_patch_version ${qtbase_version}-0)
 superbuild_package(
   NAME           qtbase
@@ -134,7 +134,7 @@ superbuild_package(
   
   SOURCE
     URL             https://download.qt.io/archive/qt/${short_version}/${qtbase_version}/submodules/qtbase-everywhere-src-${qtbase_version}.tar.xz
-    URL_HASH        SHA256=331dafdd0f3e8623b51bd0da2266e7e7c53aa8e9dc28a8eb6f0b22609c5d337e
+    URL_HASH        SHA256=8088f174e6d28e779516c083b6087b6a9e3c8322b4bc161fd1b54195e3c86940
     
     # Don't accidently used bundled copies
     PATCH_COMMAND
@@ -341,6 +341,11 @@ superbuild_package(
     # Don't accidently used bundled copies
     PATCH_COMMAND
       "${CMAKE_COMMAND}" -E remove_directory src/3rdparty/libtiff
+    COMMAND
+      "${CMAKE_COMMAND}"
+        -Dpackage=qt-${short_version}-openorienteering-${openorienteering_version}/qtimageformats
+        -P "${APPLY_PATCHES_SERIES}"
+	  
   
   USING qmake USE_SYSTEM_QT module short_version openorienteering_version qtimageformats_version
   BUILD_CONDITION  ${use_system_qt}
@@ -498,6 +503,11 @@ superbuild_package(
   SOURCE
     URL             https://download.qt.io/archive/qt/${short_version}/${version}/submodules/qttools-everywhere-src-${version}.tar.xz
     URL_HASH        SHA256=860a97114d518f83c0a9ab3742071da16bb018e6eb387179d5764a8dcca03948
+    
+    PATCH_COMMAND
+      "${CMAKE_COMMAND}"
+        -Dpackage=qt-${short_version}-openorienteering-${openorienteering_version}/qttools
+        -P "${APPLY_PATCHES_SERIES}"
 )
 
 set(module Qt5LinguistTools)  # proxy

--- a/qt-5.12.10.cmake
+++ b/qt-5.12.10.cmake
@@ -30,7 +30,7 @@
 set(short_version  5.12)
 set(version        5.12.7)
 set(patch_version  ${version}-0)
-set(openorienteering_version ${version}-qtbase-5.12.10-0)
+set(openorienteering_version ${version}-qtbase-5.12.10-1)
 
 option(USE_SYSTEM_QT "Use the system Qt if possible" ON)
 
@@ -102,7 +102,7 @@ superbuild_package(
   
   SOURCE
     URL            https://github.com/OpenOrienteering/superbuild/archive/qt-${short_version}-openorienteering_${openorienteering_version}.tar.gz
-    URL_HASH       SHA256=fa6bd764f42b32bdf3cea6999d26edb319f41cf1dba4995b062e31740076e5fe
+    URL_HASH       SHA256=fc5031097b0c4750f59ba28f84df08c5e378499267681902ad1b3b32435b0162
 )
 
 
@@ -110,7 +110,7 @@ superbuild_package(
 # qtbase
 
 set(qtbase_version       5.12.10)
-set(qtbase_patch_version ${qtbase_version}-0)
+set(qtbase_patch_version ${qtbase_version}-1)
 superbuild_package(
   NAME           qtbase
   VERSION        ${short_version}

--- a/qt-5.12.9.cmake
+++ b/qt-5.12.9.cmake
@@ -644,15 +644,14 @@ superbuild_package(
 
 find_package(Git QUIET)
 find_package(PythonInterp 3 QUIET)
-if(GIT_EXECUTABLE AND PYTHONINTERP_FOUND
-   AND "${openorienteering_version}" STREQUAL "${patch_version}")
+if(GIT_EXECUTABLE AND PYTHONINTERP_FOUND)
     superbuild_package(
       NAME           qt-${short_version}-openorienteering
       VERSION        git
       DEPENDS
         qttools-qtattributionsscanner-${patch_version}
         source:qtandroidextras-everywhere-src-${patch_version}
-        source:qtbase-everywhere-src-${patch_version}
+        source:qtbase-everywhere-src-${qtbase_patch_version}
         source:qtimageformats-everywhere-src-${patch_version}
         source:qtlocation-everywhere-src-${patch_version}
         source:qtsensors-everywhere-src-${patch_version}
@@ -663,6 +662,24 @@ if(GIT_EXECUTABLE AND PYTHONINTERP_FOUND
       SOURCE
         GIT_REPOSITORY https://github.com/OpenOrienteering/superbuild.git
         GIT_TAG        qt-${short_version}-openorienteering
+      PATCH_COMMAND
+        "${CMAKE_COMMAND}" -E make_directory "source/"
+      COMMAND
+        "${CMAKE_COMMAND}" -E create_symlink "<SOURCE_DIR>/../qtandroidextras-everywhere-src-${patch_version}" "source/qtandroidextras"
+      COMMAND
+        "${CMAKE_COMMAND}" -E create_symlink "<SOURCE_DIR>/../qtbase-everywhere-src-${qtbase_patch_version}" "source/qtbase"
+      COMMAND
+        "${CMAKE_COMMAND}" -E create_symlink "<SOURCE_DIR>/../qtimageformats-everywhere-src-${patch_version}" "source/qtimageformats"
+      COMMAND
+        "${CMAKE_COMMAND}" -E create_symlink "<SOURCE_DIR>/../qtlocation-everywhere-src-${patch_version}" "source/qtlocation"
+      COMMAND
+        "${CMAKE_COMMAND}" -E create_symlink "<SOURCE_DIR>/../qtsensors-everywhere-src-${patch_version}" "source/qtsensors"
+      COMMAND
+        "${CMAKE_COMMAND}" -E create_symlink "<SOURCE_DIR>/../qtserialport-everywhere-src-${patch_version}" "source/qtserialport"
+      COMMAND
+        "${CMAKE_COMMAND}" -E create_symlink "<SOURCE_DIR>/../qttools-everywhere-src-${patch_version}" "source/qttools"
+      COMMAND
+        "${CMAKE_COMMAND}" -E create_symlink "<SOURCE_DIR>/../qttranslations-everywhere-src-${patch_version}" "source/qttranslations"
       
       USING patch_version PYTHON_EXECUTABLE
       BUILD [[

--- a/sqlite3-3.34.0.cmake
+++ b/sqlite3-3.34.0.cmake
@@ -27,12 +27,12 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set(version           3.33.0)
-set(download_version  2020/sqlite-autoconf-3330000)
-set(download_hash     SHA3_256=6e94e9453cedf8f2023e3923f856741d1e28a2271e9f93d24d95fa48870edaad)
+set(version           3.34.0)
+set(download_version  2020/sqlite-autoconf-3340000)
+set(download_hash     SHA3_256=b7479a5b163f1ba0dd5208e247c1ea677373a2b6bf9ef8ed87c8414f58c61de3)
 set(patch_version     ${version}-1)
-set(patch_hash        SHA256=acbfdb13e248e43e8eaf19654d48070f37738ee522c79d6229797115d2ded45c)
-set(base_url          https://snapshot.debian.org/archive/debian/20200815T204602Z/pool/main/s/sqlite3/)
+set(patch_hash        SHA256=cdce039f7cf5bbde36855ff70864655cc2e514fcb6e2d8d89bfa58484bb75da6)
+set(base_url          https://snapshot.debian.org/archive/debian/20201205T034710Z/pool/main/s/sqlite3/)
 
 option(USE_SYSTEM_SQLITE3 "Use the system sqlite if possible" ON)
 

--- a/tiff-4.1.0.cmake
+++ b/tiff-4.1.0.cmake
@@ -29,11 +29,11 @@
 
 # https://tracker.debian.org/pkg/tiff
 
-set(version        4.1.0+git191117)
-set(download_hash  SHA256=67e1d045e994adb7144b0cca228d70dd6d520aaf8c75c342064bc0fd601e6e42)
-set(patch_version  ${version}-2+deb10u1)
-set(patch_hash     SHA256=e9dcc77d338663f6be84efe32ae5d4ec9b48923c731aa939f37aa909e60d9f10)
-set(base_url       https://snapshot.debian.org/archive/debian/20200125T212854Z/pool/main/t/tiff/)
+set(version        4.1.0+git201212)
+set(download_hash  SHA256=bebb2ad5537638159ff026c933ae769ab720afb8cd7b9f3bf7533db673b8636c)
+set(patch_version  ${version}-1)
+set(patch_hash     SHA256=4a5a87e944b8028fc64d22be950bf6b69ed85d4bd9269c70b27f240ac8e2073c)
+set(base_url       https://snapshot.debian.org/archive/debian/20201214T025122Z/pool/main/t/tiff/)
 
 option(USE_SYSTEM_LIBTIFF "Use the system libtiff if possible" ON)
 
@@ -63,10 +63,10 @@ set(extra_flags "-Wno-unused-parameter -Wno-unused-but-set-variable -Wno-tautolo
 
 superbuild_package(
   NAME           tiff-patches
-  VERSION        ${version}-2+deb10u1
+  VERSION        ${patch_version}
   
   SOURCE
-    URL            ${base_url}tiff_${version}-2~deb10u1.debian.tar.xz
+    URL            ${base_url}tiff_${patch_version}.debian.tar.xz
     URL_HASH       ${patch_hash}
 )
   

--- a/uriparser-0.9.4.cmake
+++ b/uriparser-0.9.4.cmake
@@ -1,0 +1,97 @@
+# This file is part of OpenOrienteering.
+
+# Copyright 2020 Kai Pastor
+#
+# Redistribution and use is allowed according to the terms of the BSD license:
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 
+# 1. Redistributions of source code must retain the copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. The name of the author may not be used to endorse or promote products 
+#    derived from this software without specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+set(version        0.9.4+dfsg)
+set(download_hash  SHA256=3558e9fce140f3587fe29bb3c7911dcc0c2abd32d34025f7d50b54e4469f4c37)
+set(patch_version  ${version}-1)
+set(patch_hash     SHA256=acd10773fc71dba64fa4072d295409dcdbffe0b589c8b052d5a6a794c6faf8f9)
+set(base_url       https://snapshot.debian.org/archive/debian/20201105T220209Z/pool/main/u/uriparser/)
+
+option(USE_SYSTEM_URIPARSER "Use the system uriparser if possible" ON)
+
+set(test_system_uriparser [[
+	if(${USE_SYSTEM_URIPARSER})
+		enable_language(C)
+		find_library(URIPARSER_LIBRARY NAMES uriparser QUIET)
+		find_path(URIPARSER_INCLUDE_DIR NAMES uriparser/Uri.h QUIET)
+		string(FIND "${URIPARSER_LIBRARY}" "${CMAKE_STAGING_PREFIX}/" staging_prefix_start)
+		if(URIPARSER_LIBRARY AND URIPARSER_INCLUDE_DIR AND NOT staging_prefix_start EQUAL 0)
+			message(STATUS "Found ${SYSTEM_NAME} uriparser: ${URIPARSER_LIBRARY}")
+			set(BUILD_CONDITION 0)
+		endif()
+	endif()
+]])
+
+superbuild_package(
+  NAME           uriparser-patches
+  VERSION        ${patch_version}
+  
+  SOURCE
+    URL            ${base_url}uriparser_${patch_version}.debian.tar.xz
+    URL_HASH       ${patch_hash}
+)
+  
+superbuild_package(
+  NAME           uriparser
+  VERSION        ${patch_version}
+  DEPENDS
+    source:uriparser-patches-${patch_version}
+    googletest
+    zlib
+  
+  SOURCE
+    URL            ${base_url}uriparser_${version}.orig.tar.xz
+    URL_HASH       ${download_hash}
+    PATCH_COMMAND
+      "${CMAKE_COMMAND}"
+        -Dpackage=uriparser-patches-${patch_version}
+        -P "${APPLY_PATCHES_SERIES}"
+    COMMAND
+      sed -e "s/WSAAPI inet_ntop/WSAAPI inet_ntop_UNUSED/" -i -- tool/uriparse.c
+  
+  USING            USE_SYSTEM_URIPARSER patch_version
+  BUILD_CONDITION  ${test_system_uriparser}
+  BUILD [[
+    CMAKE_ARGS
+      "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}"
+      "-DCMAKE_BUILD_TYPE:STRING=$<CONFIG>"
+      -DBUILD_SHARED_LIBS=ON
+      -DURIPARSER_BUILD_DOCS=OFF
+      $<$<BOOL:@CMAKE_CROSSCOMPILING@>:
+        -DURIPARSER_BUILD_TESTS=OFF
+        -DURIPARSER_BUILD_TOOLS=OFF
+      >
+   INSTALL_COMMAND
+     "${CMAKE_COMMAND}" --build . --target install/strip/fast
+   COMMAND
+     "${CMAKE_COMMAND}" -E copy
+       "<SOURCE_DIR>/../uriparser-patches-${patch_version}/copyright"
+       "${DESTDIR}${CMAKE_STAGING_PREFIX}/share/doc/copyright/uriparser-${patch_version}.txt"
+  ]]
+)


### PR DESCRIPTION
libkml is widely used, but poorly maintained. It significantly improves KML support in GDAL.

Manually tested with https://github.com/OpenOrienteering/mapper/pull/1793:
- [x] Windows 10 x64
- [x] Android 4.4 arm-v7

Tasks:
- [x] Fix minizip linking on Linux
- [x] Review copyright for boost subset