### PR TITLE
CI: Update Ubuntu Actions runner image

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -83,6 +83,7 @@ jobs:
       parameters:
         cmakeArgs: >
           -DMapper_GIT_GDAL_DATA_DIR=$(SUPERBUILD_INSTALL_DIR)/share/gdal
+          -DUSE_SYSTEM_OPENJPEG=OFF
     - template: build-iwyu.yml
     - template: publish.yml
 

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -1,6 +1,6 @@
 # This file is part of OpenOrienteering.
 
-# Copyright 2019-2024 Kai Pastor
+# Copyright 2019-2025 Kai Pastor
 #
 # Redistribution and use is allowed according to the terms of the BSD license:
 #
@@ -36,7 +36,7 @@ parameters:
 jobs:
 - job: Source
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-22.04'
   steps:
   - template: source.yml
 
@@ -73,7 +73,7 @@ jobs:
   timeoutInMinutes: 120
   dependsOn: macOS
   variables:
-    IMAGE_NAME: 'ubuntu-20.04'
+    IMAGE_NAME: 'ubuntu-22.04'
     SUPERBUILD_INSTALL_DIR: $(HOME)/superbuild
   pool:
     vmImage: '$(IMAGE_NAME)'
@@ -92,7 +92,7 @@ jobs:
   timeoutInMinutes: 120
   dependsOn: Source
   variables:
-    IMAGE_NAME: 'ubuntu-20.04'
+    IMAGE_NAME: 'ubuntu-22.04'
     SUPERBUILD_INSTALL_DIR: $(HOME)/superbuild
     TARGET: x86_64-w64-mingw32
     TARGET_SUFFIX: -$(TARGET)

--- a/ci/build-iwyu.yml
+++ b/ci/build-iwyu.yml
@@ -43,5 +43,11 @@ steps:
           iwyu-*)             make "${TARGET}" ;;
         esac
       done
+  condition: False
   displayName: 'Build iwyu'
-
+- bash: |
+    set -x
+    set -e
+    sudo apt-get install iwyu
+  condition: True
+  displayName: 'Install system iwyu'

--- a/ci/setup-ubuntu.yml
+++ b/ci/setup-ubuntu.yml
@@ -34,7 +34,7 @@ steps:
     
     sudo apt-get update
     sudo apt-get install \
-      doxygen graphviz python-lxml \
+      doxygen graphviz python3-lxml \
       g++-mingw-w64-x86-64 \
       '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev \
       sharutils


### PR DESCRIPTION
According to [The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01](https://github.com/actions/runner-images/issues/11101)

> Workflows using the ubuntu-20.04 image label should be updated to ubuntu-latest, ubuntu-22.04, ubuntu-24.04.

Closes [Update Ubuntu Actions runner image](https://github.com/OpenOrienteering/mapper/issues/2329).